### PR TITLE
v1.1.4 getAgenciesThatHasHoldingsFor() compatibility for updateservice

### DIFF
--- a/access/src/main/resources/holdingsitems/migration/V5__ThreeLevelStructure.sql
+++ b/access/src/main/resources/holdingsitems/migration/V5__ThreeLevelStructure.sql
@@ -96,5 +96,4 @@ ALTER TABLE holdingsitemsitem
     ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
 
 ALTER TABLE holdingsitemsitem RENAME TO item;
-CREATE VIEW holdingsitemsitem AS SELECT * FROM item;
 

--- a/access/src/main/resources/holdingsitems/migration/V7__compatibility.sql
+++ b/access/src/main/resources/holdingsitems/migration/V7__compatibility.sql
@@ -1,0 +1,3 @@
+CREATE VIEW holdingsitemscollection AS SELECT * FROM issue;
+CREATE VIEW holdingsitemsitem AS SELECT * FROM item;
+


### PR DESCRIPTION
To allow for easy migration - with metascrum/update-service in current version.