### PR TITLE
Flush when writing to database, needed for multiple updates of same id

### DIFF
--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/BibliographicItemEntity.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/BibliographicItemEntity.java
@@ -147,6 +147,7 @@ public class BibliographicItemEntity implements Serializable {
             em.merge(this);
         }
         persisted();
+        em.flush();
     }
 
     void persisted() {
@@ -177,6 +178,8 @@ public class BibliographicItemEntity implements Serializable {
             issue.setModified(modified);
             issue.setTrackingId(trackingId);
             issues.add(issue);
+        } else {
+            issue.persist = false;
         }
         issue.pessimisticForceIncrement = pessimisticForceIncrement;
         issue.em = em;

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/IssueEntity.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/IssueEntity.java
@@ -233,6 +233,8 @@ public class IssueEntity implements Serializable {
             item.setModified(modified);
             item.setTrackingId(trackingId);
             items.add(item);
+        } else {
+            item.persist = false;
         }
         item.owner = this;
         return item;


### PR DESCRIPTION
`.flush()` er den magiske... resten er bare sætte en bool til false, hvilket den er alligevel (usat), det er bare nemmere at læse.