### PR TITLE
HIU 5 - Remove decommissioned state from database

### DIFF
--- a/access/src/main/java/dk/dbc/holdingsitems/StateChangeMetadata.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/StateChangeMetadata.java
@@ -18,6 +18,7 @@
  */
 package dk.dbc.holdingsitems;
 
+import dk.dbc.holdingsitems.jpa.ItemEntity;
 import dk.dbc.holdingsitems.jpa.Status;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
@@ -34,6 +35,10 @@ public class StateChangeMetadata {
 
     public StateChangeMetadata(Status oldStatus, Instant when) {
         this(oldStatus, oldStatus, when);
+    }
+
+    public static StateChangeMetadata from(ItemEntity item) {
+        return new StateChangeMetadata(item.getStatus(), item.getModified());
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/IssueKey.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/IssueKey.java
@@ -79,4 +79,8 @@ public class IssueKey implements Serializable {
                Objects.equals(this.issueId, other.issueId);
     }
 
+    @Override
+    public String toString() {
+        return "IssueKey{" + "agencyId=" + getAgencyId() + ", bibliographicRecordId=" + getBibliographicRecordId() + ", issueId=" + issueId + '}';
+    }
 }

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/ItemEntity.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/ItemEntity.java
@@ -118,7 +118,6 @@ public class ItemEntity implements Serializable {
         @JoinColumn(name = "issueId", referencedColumnName = "issueId",
                     insertable = false, updatable = false)
     })
-
     @ManyToOne(cascade = CascadeType.ALL)
     IssueEntity owner;
 
@@ -148,6 +147,7 @@ public class ItemEntity implements Serializable {
 
     public void remove() {
         owner.removeItem(this);
+        owner = null;
     }
 
     void persisted() {

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/ItemKey.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/ItemKey.java
@@ -90,4 +90,8 @@ public class ItemKey implements Serializable {
                Objects.equals(this.itemId, other.itemId);
     }
 
+    @Override
+    public String toString() {
+        return "ItemKey{" + "agencyId=" + getAgencyId() + ", bibliographicRecordId=" + getBibliographicRecordId() + ", issueId=" + getIssueId() + ", itemId=" + itemId + '}';
+    }
 }

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/Status.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/Status.java
@@ -34,7 +34,7 @@ public enum Status {
     NOT_FOR_LOAN("NotForLoan"),
     ON_LOAN("OnLoan"),
     ON_SHELF("OnShelf"),
-    DECOMMISSIONED("Decommissioned"),
+    DECOMMISSIONED("Decommissioned"), // THIS CANNOT BE STORED IN DATABASE ANY LONGER
     ONLINE("Online"),
     UNKNOWN("UNKNOWN");
 

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/StatusConverter.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/StatusConverter.java
@@ -30,6 +30,8 @@ public class StatusConverter implements AttributeConverter<Status, String> {
 
     @Override
     public String convertToDatabaseColumn(Status status) {
+        if(status == Status.DECOMMISSIONED)
+            throw new IllegalArgumentException("Cannot store status=Deprecated in database any more");
         return status.toString();
     }
 

--- a/access/src/main/java/dk/dbc/holdingsitems/jpa/StatusConverter.java
+++ b/access/src/main/java/dk/dbc/holdingsitems/jpa/StatusConverter.java
@@ -31,7 +31,7 @@ public class StatusConverter implements AttributeConverter<Status, String> {
     @Override
     public String convertToDatabaseColumn(Status status) {
         if(status == Status.DECOMMISSIONED)
-            throw new IllegalArgumentException("Cannot store status=Deprecated in database any more");
+            throw new IllegalArgumentException("Cannot store status=Deprecated in database anymore");
         return status.toString();
     }
 

--- a/access/src/test/java/dk/dbc/holdingsitems/JpaBase.java
+++ b/access/src/test/java/dk/dbc/holdingsitems/JpaBase.java
@@ -62,14 +62,21 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void jpa(JpaVoidExecution ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
-        e.getPersistenceContext().run(() -> ex.execute(em));
+        e.getPersistenceContext().run(() -> {
+            ex.execute(em);
+        });
     }
 
     public <T> T jpa(JpaExecution<T> ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
-        return e.getPersistenceContext().run(() -> ex.execute(em));
+        return e.getPersistenceContext().run(() -> {
+            T t = ex.execute(em);
+            return t;
+        });
     }
 
     public void flushAndEvict() {
@@ -125,7 +132,7 @@ public class JpaBase extends JpaIntegrationTest {
 
         String userName = System.getProperty("user.name");
         if (testPort != null) {
-            ds.setServerNames(new String[] {"localhost"} );
+            ds.setServerNames(new String[] {"localhost"});
             ds.setDatabaseName(databaseName);
             ds.setUser(userName);
             ds.setPassword(userName);

--- a/content/src/test/java/JpaBase.java
+++ b/content/src/test/java/JpaBase.java
@@ -1,11 +1,6 @@
 import dk.dbc.commons.persistence.JpaIntegrationTest;
 import dk.dbc.commons.persistence.JpaTestEnvironment;
 import dk.dbc.holdingsitems.DatabaseMigrator;
-import dk.dbc.holdingsitems.jpa.BibliographicItemEntity;
-import dk.dbc.holdingsitems.jpa.IssueEntity;
-import dk.dbc.holdingsitems.jpa.ItemEntity;
-import dk.dbc.holdingsitems.jpa.LoanRestriction;
-import dk.dbc.holdingsitems.jpa.Status;
 import org.junit.Before;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
@@ -16,8 +11,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.util.Map;
 
 /**
@@ -41,12 +34,14 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void jpa(JpaVoidExecution ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         e.getPersistenceContext().run(() -> ex.execute(em));
     }
 
     public <T> T jpa(JpaExecution<T> ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         return e.getPersistenceContext().run(() -> ex.execute(em));
     }

--- a/kafka-bridge/src/test/java/dk/dbc/holdingsitems/kafkabridge/JpaBase.java
+++ b/kafka-bridge/src/test/java/dk/dbc/holdingsitems/kafkabridge/JpaBase.java
@@ -63,6 +63,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void jpa(JpaVoidExecution ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         e.getPersistenceContext().run(() -> {
             try {
@@ -77,6 +78,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public <T> T jpa(JpaExecution<T> ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         return e.getPersistenceContext().run(() -> {
             try {

--- a/purge-tool/src/main/java/dk/dbc/holdingsitems/purge/Arguments.java
+++ b/purge-tool/src/main/java/dk/dbc/holdingsitems/purge/Arguments.java
@@ -86,21 +86,15 @@ public final class Arguments {
                     .longOpt("dry-run")
                     .desc("Only simulate")
                     .build();
-    private final Option keepDecommissioned =
-            Option.builder("k")
-                    .longOpt("keep")
-                    .desc("Keep decommissioned records (mutually exclusive with --remove)")
-                    .build();
     private final Option removeFirstAcquisitionDate =
             Option.builder("r")
                     .longOpt("remove")
-                    .desc("Remove first acquisition date (remove all data from database - irreversible) (mutually exclusive with --keep)")
+                    .desc("Remove first acquisition date (remove all data from database - irreversible)")
                     .build();
     private final Options options = new Options()
             .addOption(agencyId)
             .addOption(openAgency)
             .addOption(database)
-            .addOption(keepDecommissioned)
             .addOption(removeFirstAcquisitionDate)
             .addOption(queue)
             .addOption(verbose)
@@ -132,8 +126,6 @@ public final class Arguments {
             missing = "Required options: " + missing + " are missing";
             throw new ExitException(usage(missing));
         }
-        if (hasKeepDecommissioned() && hasRemoveFirstAcquisitionDate())
-            throw new ExitException(usage("--keep/--remove are mutually exclusive"));
     }
 
     private CommandLine parse(Options options, List<Option> required, String[] args) throws ExitException {
@@ -178,10 +170,6 @@ public final class Arguments {
 
     public boolean hasRemoveFirstAcquisitionDate() {
         return commandLine.hasOption(removeFirstAcquisitionDate.getOpt());
-    }
-
-    public boolean hasKeepDecommissioned() {
-        return commandLine.hasOption(keepDecommissioned.getOpt());
     }
 
     public boolean hasDryRun() {

--- a/purge-tool/src/main/java/dk/dbc/holdingsitems/purge/PurgeMain.java
+++ b/purge-tool/src/main/java/dk/dbc/holdingsitems/purge/PurgeMain.java
@@ -78,10 +78,6 @@ public class PurgeMain {
             String queue = commandLine.getQueue();
             log.info("Queue: {}", queue);
 
-            boolean keepDecommissioned = commandLine.hasKeepDecommissioned();
-            if (keepDecommissioned) {
-                log.info("Will not remove decommissioned records");
-            }
             boolean removeFirstAcquisitionDate = commandLine.hasRemoveFirstAcquisitionDate();
             if (removeFirstAcquisitionDate) {
                 log.info("Will remove ALL traces of the agency");
@@ -123,14 +119,6 @@ public class PurgeMain {
                     PurgeReport purgeReport = new PurgeReport(dao, agencyId);
                     purgeReport.statusReport();
                 });
-
-                if (!keepDecommissioned) {
-                    jpa.run(em -> {
-                        HoldingsItemsDAO dao = HoldingsItemsDAO.newInstance(em, trackingId);
-                        Purge purge = new Purge(em, dao, queue, agencyName, agencyId, dryRun);
-                        purge.removeDecommissioned(removeFirstAcquisitionDate);
-                    });
-                }
 
             } catch (SQLException | RuntimeException ex) {
                 log.error("Exception", ex);

--- a/purge-tool/src/test/java/dk/dbc/holdingsitems/purge/JpaBase.java
+++ b/purge-tool/src/test/java/dk/dbc/holdingsitems/purge/JpaBase.java
@@ -70,6 +70,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void exec(DaoVoidExecution exe) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         EntityTransaction transaction = em.getTransaction();
         try {
@@ -86,6 +87,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public <T> T exec(DaoExecution<T> exe) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         EntityTransaction transaction = em.getTransaction();
         try {

--- a/solr-indexer/pom.xml
+++ b/solr-indexer/pom.xml
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.17.v20190418</version>
+            <version>9.4.35.v20201120</version>
             <scope>test</scope>
         </dependency>
 

--- a/solr-indexer/src/test/java/dk/dbc/holdingsitems/indexer/JpaBase.java
+++ b/solr-indexer/src/test/java/dk/dbc/holdingsitems/indexer/JpaBase.java
@@ -63,6 +63,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void jpa(JpaVoidExecution ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         e.getPersistenceContext().run(() -> {
             try {
@@ -77,6 +78,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public <T> T jpa(JpaExecution<T> ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         return e.getPersistenceContext().run(() -> {
             try {

--- a/update-webservice/src/main/java/dk/dbc/holdingsitems/update/UpdateBean.java
+++ b/update-webservice/src/main/java/dk/dbc/holdingsitems/update/UpdateBean.java
@@ -316,8 +316,8 @@ public class UpdateBean {
                             Set<String> processedItems = processIssuesAndItems.getOrDefault(issueId, EMPTY_SET);
                             List<ItemEntity> decommissioned = issue.stream() // For all items
                                     .filter(item -> !processedItems.contains(item.getItemId())) // Not those present in request
-                                    .filter(item -> item.getStatus() != Status.ONLINE) // That are't online type
-                                    .filter(item -> !item.getModified().isAfter(modified)) // And hasn't been modified in the future
+                                    .filter(item -> item.getStatus() != Status.ONLINE) // That aren't online type
+                                    .filter(item -> !item.getModified().isAfter(modified)) // And haven't been modified in the future
                                     .collect(toList());
                             log.debug("decommissioned = {}", decommissioned);
                             decommissioned.forEach(item -> {

--- a/update-webservice/src/main/java/dk/dbc/holdingsitems/update/UpdateBean.java
+++ b/update-webservice/src/main/java/dk/dbc/holdingsitems/update/UpdateBean.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -69,6 +69,9 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXParseException;
+
+import static java.util.Collections.EMPTY_SET;
+import static java.util.stream.Collectors.toList;
 
 /**
  *
@@ -226,7 +229,7 @@ public class UpdateBean {
 
                                     bibliographicItem.getHoldings().stream()
                                             .sorted(HOLDINGS_SORT_COMPARE)
-                                            .forEachOrdered(holding -> processHolding(modified, bibItem, false, holding));
+                                            .forEachOrdered(holding -> processHolding(modified, bibItem, holding, null));
                                     bibItem.save();
                                     addQueueJob(bibliographicRecordId, getAgencyId());
                                 }
@@ -296,36 +299,33 @@ public class UpdateBean {
                             bibItem.setTrackingId(getTrakingId());
                         }
 
-                        Set<String> handledIssues = new HashSet<>();
+                        HashMap<String, Set<String>> processIssuesAndItems = new HashMap<>();
                         bibliographicItem.getHoldings().stream()
                                 .sorted(HOLDINGS_SORT_COMPARE)
                                 .forEachOrdered(holding -> {
-                                    handledIssues.add(holding.getIssueId());
-                                    processHolding(modified, bibItem, true, holding);
+                                    processHolding(modified, bibItem, holding, processIssuesAndItems);
                                 });
                         HashMap<String, StateChangeMetadata> statuses = oldItemStatus.computeIfAbsent(bibliographicRecordId, f -> new HashMap<>());
 
-                        bibItem.stream() // For all issues
-                                .filter(issue -> !handledIssues.contains(issue.getIssueId())) // That wasn't in the request
-                                .filter(issue -> !issue.getComplete().isAfter(modified)) // And hasn't been changed in the furure
-                                .forEach(issue -> {
-                                    issue.setComplete(modified)
-                                            .setModified(modified)
-                                            .setTrackingId(getTrakingId());
-                                    issue.stream() // For al items
-                                            .filter(item -> item.getStatus() != Status.ONLINE) // That are't online type
-                                            .filter(item -> !item.getModified().isAfter(modified)) // Han hasn't been modified in the future
-                                            .forEach(item -> {
-                                                statuses.computeIfAbsent(item.getItemId(), i -> new StateChangeMetadata(item.getStatus(), item.getModified()))
-                                                        .update(Status.DECOMMISSIONED, modified);
-
-                                                item.setStatus(Status.DECOMMISSIONED)
-                                                        .setModified(modified)
-                                                        .setTrackingId(getTrakingId());
-
-                                            });
-
-                                });
+                        bibItem.stream().forEach(issue -> {
+                            if (issue.getComplete().isBefore(modified)) {
+                                issue.setComplete(modified);
+                            }
+                            String issueId = issue.getIssueId();
+                            log.debug("issueId = {}", issueId);
+                            Set<String> processedItems = processIssuesAndItems.getOrDefault(issueId, EMPTY_SET);
+                            List<ItemEntity> decommissioned = issue.stream() // For all items
+                                    .filter(item -> !processedItems.contains(item.getItemId())) // Not those present in request
+                                    .filter(item -> item.getStatus() != Status.ONLINE) // That are't online type
+                                    .filter(item -> !item.getModified().isAfter(modified)) // And hasn't been modified in the future
+                                    .collect(toList());
+                            log.debug("decommissioned = {}", decommissioned);
+                            decommissioned.forEach(item -> {
+                                statuses.computeIfAbsent(item.getItemId(), i -> new StateChangeMetadata(item.getStatus(), item.getModified()))
+                                        .update(Status.DECOMMISSIONED, modified);
+                                item.remove();
+                            });
+                        });
                         bibItem.save();
                         addQueueJob(bibliographicRecordId, getAgencyId());
                     }
@@ -407,7 +407,7 @@ public class UpdateBean {
                         if (bibliographicItem.isHasOnlineHolding()) {
                             rec.setStatus(Status.ONLINE);
                         } else {
-                            rec.setStatus(Status.DECOMMISSIONED);
+                            rec.remove();
                         }
                         if (rec.isNew()) {
                             rec.setBranch("");

--- a/update-webservice/src/test/java/dk/dbc/holdingsitems/update/JpaBase.java
+++ b/update-webservice/src/test/java/dk/dbc/holdingsitems/update/JpaBase.java
@@ -63,6 +63,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public void jpa(JpaVoidExecution ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         e.getPersistenceContext().run(() -> {
             try {
@@ -77,6 +78,7 @@ public class JpaBase extends JpaIntegrationTest {
 
     public <T> T jpa(JpaExecution<T> ex) {
         JpaTestEnvironment e = env();
+        e.reset();
         EntityManager em = e.getEntityManager();
         return e.getPersistenceContext().run(() -> {
             try {

--- a/update-webservice/src/test/java/dk/dbc/holdingsitems/update/UpdateBeanIT.java
+++ b/update-webservice/src/test/java/dk/dbc/holdingsitems/update/UpdateBeanIT.java
@@ -59,7 +59,6 @@ import javax.xml.ws.WebServiceContext;
 import javax.xml.ws.handler.MessageContext;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Timer;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -206,7 +205,6 @@ public class UpdateBeanIT extends JpaBase {
         });
         getQueue(); // Just for logging
         clearQueue();
-
         jpa(em -> {
             mockUpdateBean(em)
                     .completeHoldingsItemsUpdate(completeReq3());
@@ -284,12 +282,8 @@ public class UpdateBeanIT extends JpaBase {
         System.out.println("status = " + respOnline.getHoldingsItemsUpdateStatusMessage());
         assertEquals("Expedcted success from request", HoldingsItemsUpdateStatusEnum.OK, respOnline.getHoldingsItemsUpdateStatus());
         assertEquals("Expected collections", 4, countAllCollections());
-        assertEquals("Expected items", 5, countAllItems());
-        assertEquals("Expected decommissioned", 3, countItems(StatusType.DECOMMISSIONED));
+        assertEquals("Expected items", 2, countAllItems());
         assertEquals("Expected online", 1, countItems(StatusType.ONLINE));
-        HashMap<String, String> row = checkRow(101010, "12345678", "I1", "it1-1");
-        assertNotNull("Expected a row", row);
-        assertEquals("complete time as new update", "2017-09-07T09:09:01.001Z", row.get("c.complete"));
     }
 
     @Test(timeout = 2_000L)
@@ -429,68 +423,6 @@ public class UpdateBeanIT extends JpaBase {
         }
     }
 
-    @Test(timeout = 2_000L)
-    public void testThat114TypeGetAgenciesThatHasHoldingsForWorks() throws Exception {
-        System.out.println("testThat114TypeGetAgenciesThatHasHoldingsForWorks");
-
-        jpa(em -> {
-            HoldingsItem item = item("it1-1", branch, "234567", department, location, subLocation, circulationRule,
-                                     StatusType.DECOMMISSIONED, date("2017-01-01"));
-            item.setLoanRestriction(null);
-            HoldingsItemsUpdateRequest req =
-                    holdingsItemsUpdateRequest(101010, null, "track-update-1",
-                                               bibliographicItem("12345678", modified("2017-09-07T09:09:00.001Z"), "Original Note",
-                                                                 holding("I1", "Issue #1", date("2199-01-01"), 0, item)));
-            mockUpdateBean(em).holdingsItemsUpdate(req);
-        });
-        jpa(em -> {
-            HoldingsItem item = item("it1-1", branch, "234567", department, location, subLocation, circulationRule,
-                                     StatusType.ON_LOAN, date("2017-01-01"));
-            item.setLoanRestriction(null);
-            HoldingsItemsUpdateRequest req =
-                    holdingsItemsUpdateRequest(101011, null, "track-update-1",
-                                               bibliographicItem("12345678", modified("2017-09-07T09:09:00.001Z"), "Original Note",
-                                                                 holding("I1", "Issue #1", date("2199-01-01"), 0, item)));
-            mockUpdateBean(em).holdingsItemsUpdate(req);
-        });
-        jpa(em -> {
-            HoldingsItem item = item("it1-1", branch, "234567", department, location, subLocation, circulationRule,
-                                     StatusType.ON_SHELF, date("2017-01-01"));
-            item.setLoanRestriction(null);
-            HoldingsItemsUpdateRequest req =
-                    holdingsItemsUpdateRequest(101012, null, "track-update-1",
-                                               bibliographicItem("12345678", modified("2017-09-07T09:09:00.001Z"), "Original Note",
-                                                                 holding("I1", "Issue #1", date("2199-01-01"), 0, item)));
-            mockUpdateBean(em).holdingsItemsUpdate(req);
-        });
-
-        try (Connection connection = dataSource.getConnection()) {
-            Set<Integer> agencies = getAgenciesThatHasHoldingsFor114(connection, "12345678");
-            assertThat(agencies, Matchers.containsInAnyOrder(101011, 101012));
-        }
-    }
-
-    // 1.1.4 START
-    private static final String AGENCIES_WITH_BIBLIOGRAPHICRECORDID = "SELECT DISTINCT agencyId FROM holdingsitemscollection" +
-                                                                      " JOIN holdingsitemsitem USING(agencyId, bibliographicRecordId, issueId)" +
-                                                                      " WHERE bibliographicRecordId=? AND status != 'Decommissioned'";
-
-    public Set<Integer> getAgenciesThatHasHoldingsFor114(Connection connection, String bibliographicRecordId) throws SQLException {
-        HashSet agencies = new HashSet<Integer>();
-
-        try (PreparedStatement stmt = connection.prepareStatement(AGENCIES_WITH_BIBLIOGRAPHICRECORDID)) {
-            stmt.setString(1, bibliographicRecordId);
-            try (ResultSet resultSet = stmt.executeQuery()) {
-                while (resultSet.next()) {
-                    int agency = resultSet.getInt(1);
-                    agencies.add(agency);
-                }
-            }
-        }
-        return agencies;
-    }
-    // 1.1.4 END
-
     public HoldingsItemsUpdateRequest updateReq1() throws DatatypeConfigurationException {
         return holdingsItemsUpdateRequest(
                 101010, null, "track-update-1",
@@ -568,10 +500,10 @@ public class UpdateBeanIT extends JpaBase {
                 completeBibliographicItem(
                         "12345678", modified("2017-09-07T09:09:03.001Z"), "Other Note",
                         holding("I3", "Issue #3", null, 1,
-                                item("it3-1", branch, "234567", department, location, subLocation, circulationRule,
+                                item("it3-2", branch, "234567", department, location, subLocation, circulationRule,
                                      StatusType.ON_LOAN, date("2017-01-01"))),
                         holding("I3", "Issue #3", null, 1,
-                                item("it3-2", branch, "234567", department, location, subLocation, circulationRule,
+                                item("it3-3", branch, "234567", department, location, subLocation, circulationRule,
                                      StatusType.ON_LOAN, date("2017-01-01")))));
     }
 


### PR DESCRIPTION
Jeg har ikke slettet type 'Decommissioned' i status_types tabellenm - det kommer når denne er i drift. Det vil tage for lang tid at slette dem, til at k8s vil blive utålmodig, og slå servicen (og flyway) ned. Og jeg kan ikke rulle det på i hånden, da den kørende service vil fejle undervejs. - Der er ~30M rækker med Decommissioned.

Jeg har lavet en "assert" i den klasse som mapper til database typen, hvis status er 'Decommissioned'

Der er slettet en ret stor integration test (som hedder noget med 114) da vi ikke længere supporter 1.1.4

Alle DIT test med holdingsitems er gået igennem lokalt
