### PR TITLE
Store empty loan-restriction in SolR

### DIFF
--- a/solr-indexer/src/main/java/dk/dbc/holdingsitems/indexer/logic/UniqueFields.java
+++ b/solr-indexer/src/main/java/dk/dbc/holdingsitems/indexer/logic/UniqueFields.java
@@ -48,7 +48,7 @@ public class UniqueFields {
     private final String circulationRule;
     private final Status status;
     private final LocalDate accessionDate;
-    private final LoanRestriction loanRestriction;
+    private final LoanRestriction loanRestriction; // This needs to be unique - absence should be derived from a SolR document
 
     public UniqueFields(IssueEntity collection, ItemEntity record) {
         this.agencyId = collection.getAgencyId();


### PR DESCRIPTION
This is needed to find empty/non-existing loanRestriction in holdings-service